### PR TITLE
Update SimulatorStatusMagic Pod to fix low battery

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -7,6 +7,6 @@ use_frameworks!
 inhibit_all_warnings!
 
 target 'Textor' do
-	pod 'SimulatorStatusMagic', '~> 1.9', :configurations => ['Debug']
+	pod 'SimulatorStatusMagic', '~> 2.1', :configurations => ['Debug']
 
 end


### PR DESCRIPTION
When compiled in Xcode 9 SimulatorStatusMagic 1.9 displays a low battery. 2.1 fixes it.